### PR TITLE
[DRAFT] fix: add mr18 and z1 boards

### DIFF
--- a/nu801.c
+++ b/nu801.c
@@ -80,16 +80,38 @@ struct hardware_definitions {
 		.colors = { "blue", "green", "red" },
 		.functions = { "tricolor", "tricolor", "tricolor" },
 	},
-
-	/*
-	 * {
-	 *	.id = "Meraki Z1",
-	 * },
-	 * {
-	 *	.id = "Meraki MR18",
-	 * }
-	 */
-
+	{
+		.id = "Meraki MR18",
+		.board = "mr18",
+		.gpio = {
+			.type = NUMBER,
+			.gpiochip = "gpiochip0",
+			.num = {
+				.cki = 11,
+				.sdi = 12,
+				.lei = -1,
+			},
+		},
+		.ndelay = 500,
+		.colors = {"red", "green", "blue" },
+		.functions = { "tricolor", "tricolor", "tricolor" },
+	},
+	{
+		.id = "Meraki Z1",
+		.board = "z1",
+		.gpio = {
+			.type = NUMBER,
+			.gpiochip = "gpiochip0",
+			.num = {
+				.cki = 14,
+				.sdi = 15,
+				.lei = -1,
+			},
+		},
+		.ndelay = 500,
+		.colors = { "blue", "green", "red" },
+		.functions = { "tricolor", "tricolor", "tricolor" },
+	},
 	{ },
 };
 


### PR DESCRIPTION
Initial work to bring these boards up. Note this is still untested code.
Board specs came from ath79/mach-z1.c and ath79/mach-mr18.c.
Note that the .id's are most likely wrong, and this shouldn't be merged
til these boards are booting on the new ath79 openwrt target.