### PR TITLE
fix format strings with PPC/MIPS64

### DIFF
--- a/nu801.c
+++ b/nu801.c
@@ -29,6 +29,10 @@
 #include <sys/select.h>
 #include <sys/ioctl.h>
 
+#ifndef __SANE_USERSPACE_TYPES__
+#define __SANE_USERSPACE_TYPES__	/* For PPC64, to get LL64 types */
+#endif
+
 #include <linux/gpio.h>
 #include <linux/uleds.h>
 


### PR DESCRIPTION
This define is needed to get consistent format strings with 64-bit
systems.

Signed-off-by: Rosen Penev <rosenp@gmail.com>